### PR TITLE
Bump swc_core to 0.59

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,19 +146,20 @@ dependencies = [
 
 [[package]]
 name = "bytecheck"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
+checksum = "13fe11640a23eb24562225322cd3e452b93a3d4091d62fab69c70542fcd17d1f"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
+ "simdutf8",
 ]
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
+checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -185,7 +186,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "swc_common",
  "swc_core",
 ]
 
@@ -896,6 +896,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,6 +1165,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,6 +1209,19 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "static_assertions"
@@ -1276,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "0.4.24"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79642938ff437f2217718abf30a3450b014f600847c8f4bd60fa44f88a5210ea"
+checksum = "5a172f2e444ae1378286cd27ff2a5cb26eadfd7a77c98ccb0edde8992857be1e"
 dependencies = [
  "once_cell",
  "rkyv",
@@ -1291,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.29.13"
+version = "0.29.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953e1f014688eadbbd3e9131a525e8922c552540bb02b0bb6d9fdcb1375bccc4"
+checksum = "a8a75c46065858a37cdda2c1c6fd056986e3b7752d5ec332e91ce312c6a22749"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1349,16 +1377,18 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.40.36"
+version = "0.59.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3751a11e268d3766d252575fa54f195a185347bd0b80729189bc2c5b6c312df8"
+checksum = "68f5e05fb254be0384197b7d5ba19ad5f73764c754f96d49683ca8c86f9c1283"
 dependencies = [
  "once_cell",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
+ "swc_ecma_parser",
  "swc_ecma_quote_macros",
  "swc_ecma_transforms_base",
+ "swc_ecma_transforms_compat",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_testing",
  "swc_ecma_utils",
@@ -1371,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.94.17"
+version = "0.96.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc39246540303a9058283e6ef691a276c34afd8331e6873fb3e6fb7803eb77eb"
+checksum = "621c66e27fbb6cbb6434a4e2b25e439e9a2583cc3419a4a83eba51d16ac0cd7b"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -1389,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.127.28"
+version = "0.129.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a5495203741e7e8445b23bbb330cec6200f764460bd8a9d8d30271018950da"
+checksum = "ed38caed505e7e00c58e15c5dd36a1ece62c5e6b19b4efe18833747895a7a052"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -1421,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.122.23"
+version = "0.124.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6472a516d3e7f30277650353f5bdce431c273e43ba25ee918e8d0a5a0a9868eb"
+checksum = "89b3f472b3dfbfd279de364d2b014459a281824b938e243a8739037c445d6b6c"
 dependencies = [
  "either",
  "enum_kind",
@@ -1431,6 +1461,7 @@ dependencies = [
  "num-bigint",
  "serde",
  "smallvec",
+ "stacker",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -1440,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.33.24"
+version = "0.35.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe694791cb5083117e5284b205f26f02338d3896770fcc3b6ffeb8c186934aea"
+checksum = "7bb09af6bf2b3b8cb98d021ba1a110483a68b6782c55ce35e526d9b330730dc5"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -1458,25 +1489,21 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ecc467eff7ef4ec0a64919402b94da637003015d019de4d649e8efeceafd3f"
+checksum = "25198f96ef93c4bb4cc8fa13c9b22a018cf2c0c7609ee91f7abc7968ebc2e2df"
 dependencies = [
  "anyhow",
  "hex",
  "sha-1",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "testing",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.111.38"
+version = "0.116.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966bbee55bdd5380216545166820b22813b1912a5558446898c9af2865d854e2"
+checksum = "1607f54ac0a3e677f5a61aa71d47f067630af66ddf8a0f66092139520c4ca53c"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -1496,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.100.37"
+version = "0.105.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95273dc2b4aa678b2a28520c41d415835cd20b663a5635b56c5597b5dafef84f"
+checksum = "917d38414327ecef8927e78865e2b2bff0fba03e46fa1d19653844e106c654af"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1510,9 +1537,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.136.25"
+version = "0.141.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10cec6359b7ac7ff6b9aee64ffe03f3dfc6d1fa8fc7fc25f9b8fd0a4a86f381"
+checksum = "60fdf063ba20b3635b87d8476b68db6c1f53714265eba62303f716b34c4cb471"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -1549,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.155.26"
+version = "0.160.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9480119190a92fe91ec7c9738b84e3206a693b7f2b9f8cc0040cf6adde1d382f"
+checksum = "cd7d8418ffbd7a6631505d5e6d4c64bf6f22f499bad21cb2d8dcd4d0e7902111"
 dependencies = [
  "ahash",
  "base64",
@@ -1575,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.114.24"
+version = "0.119.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1521369ac9d910fa07c2be55cf05fa9294e12528942158319c76b09836e5710b"
+checksum = "05a1509a523804cf0467b84d5b801939d6305ee2a3506619d235556c3504b1de"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1601,13 +1628,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.105.28"
+version = "0.107.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffaaa56fd2d1f418b332740e618770e00adc2ceda3adf2bdbd3fb8dc1b0f89a7"
+checksum = "0e4473b78bb2d4ef4f12f9c09dd3756fc108df1a9b64375b585ff3fff80c0832"
 dependencies = [
  "indexmap",
  "num_cpus",
  "once_cell",
+ "rustc-hash",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -1618,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.80.17"
+version = "0.82.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb35536ee61f90c73fd22500911ca2edd11b1ccaad79d01b296011545a339115"
+checksum = "f7d44d0d7c3cf08d4553d1e37e34cd2cd56efc28ee90e49fbfa7073a9c5bbfba"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -1644,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.13.13"
+version = "0.13.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1996acb4fd0656d77769764e93ca486810d6baa724a8ed877a7ae3cc7f7c6b5"
+checksum = "ac5eac14b6e9f53f19b6366e848677f34e44c15916b76dcfaa2e600ddea4aa2c"
 dependencies = [
  "anyhow",
  "miette",
@@ -1661,9 +1689,6 @@ version = "0.0.1"
 dependencies = [
  "common",
  "swc_core",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_compat",
  "testing",
 ]
 
@@ -1673,9 +1698,6 @@ version = "0.1.0"
 dependencies = [
  "common",
  "swc_core",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_compat",
  "testing",
 ]
 
@@ -1702,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_macro"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4241e5cbfb7aae61603ca4d161e132012f488cf86393855c5cd5dddbbfe34382"
+checksum = "8c00caf955dfbff15974f061f8c2e8a8b9b5ce999cb601f02f3ec66253e81149"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1713,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.22.17"
+version = "0.25.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2725ea87c315b1ccd980a296542442e57dc6700641f974e670df11ed338bae"
+checksum = "cd6df98daa1e20bdfbd2f9d4c2978daa606e53d676f1b2f72d3534cb9ce880ba"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -1738,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f2bcb7223e185c4c7cbf5e0c1207dec6d2bfd5e72e3fb7b3e8d179747e9130"
+checksum = "470a1963cf182fdcbbac46e3a7fd2caf7329da0e568d3668202da9501c880e16"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -1748,9 +1770,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb1f3561674d84947694d41fb6d5737d19539222779baeac1b3a071a2b29428"
+checksum = "6098b717cfd4c85f5cddec734af191dbce461c39975ed567c32ac6d0c6d61a6d"
 dependencies = [
  "Inflector",
  "pmutil",
@@ -1806,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.31.13"
+version = "0.31.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a510616ec857597e5eaa33977e2aab5df08385cf7d69bd68bf55763fdf120b2"
+checksum = "f7aca5f119857af12a8f66be31c9dd2a173d9fc264518fcc842136c8c81e7bfa"
 dependencies = [
  "ansi_term",
  "difference",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -11,5 +11,4 @@ lazy_static = "1.4.0"
 regex = "1.6.0"
 serde = "1.0.147"
 serde_json = "1.0.87"
-swc_common = "0.29.13"
-swc_core = { version = "0.40.36", features = ["ecma_ast"] }
+swc_core = { version = "0.59", features = ["ecma_ast", "common"] }

--- a/crates/common/src/atom_import_map.rs
+++ b/crates/common/src/atom_import_map.rs
@@ -1,5 +1,7 @@
-use swc_common::collections::AHashSet;
-use swc_core::ecma::{ast::*, atoms::JsWord};
+use swc_core::{
+    common::collections::AHashSet,
+    ecma::{ast::*, atoms::JsWord},
+};
 
 use crate::ATOM_IMPORTS;
 

--- a/crates/debug_label/Cargo.toml
+++ b/crates/debug_label/Cargo.toml
@@ -11,19 +11,18 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 common = { path = "../common" }
-swc_core = { version = "0.40.36", features = [
+swc_core = { version = "0.59", features = [
   "ecma_ast",
   "ecma_utils",
   "ecma_visit",
-  "plugin_transform", 
+  "ecma_plugin_transform",
 ] }
 
 [dev-dependencies]
-swc_core = { version = "0.40.36", features = [
+swc_core = { version = "0.59", features = [
+  "ecma_parser",
+  "ecma_transforms_compat",
   "ecma_transforms_react",
-  "testing_transform", 
+  "testing_transform",
 ] }
-swc_ecma_parser = "0.122.23"
-swc_ecma_transforms_base = "0.111.38"
-swc_ecma_transforms_compat = "0.136.25"
 testing = "0.31.13"

--- a/crates/debug_label/src/lib.rs
+++ b/crates/debug_label/src/lib.rs
@@ -239,11 +239,11 @@ mod tests {
     use swc_core::{
         common::{chain, Mark},
         ecma::{
+            parser::Syntax,
             transforms::{base::resolver, testing::test},
             visit::{as_folder, Fold},
         },
     };
-    use swc_ecma_parser::Syntax;
 
     fn transform(config: Option<Config>, path: Option<&Path>) -> impl Fold {
         chain!(

--- a/crates/debug_label/tests/fixture.rs
+++ b/crates/debug_label/tests/fixture.rs
@@ -3,13 +3,16 @@ use std::{fs::read_to_string, path::PathBuf};
 use common::parse_plugin_config;
 use swc_core::{
     common::{chain, Mark},
-    ecma::transforms::{
-        base::resolver,
-        react::{react, Options, RefreshOptions},
-        testing::test_fixture,
+    ecma::{
+        parser::{EsConfig, Syntax},
+        transforms::{
+            base::resolver,
+            compat::es2015,
+            react::{react, Options, RefreshOptions},
+            testing::test_fixture,
+        },
     },
 };
-use swc_ecma_parser::{EsConfig, Syntax};
 use swc_jotai_debug_label::debug_label;
 use testing::fixture;
 
@@ -46,7 +49,7 @@ fn test(input: PathBuf) {
                     },
                     top_level_mark
                 ),
-                swc_ecma_transforms_compat::es2015(
+                es2015(
                     unresolved_mark,
                     Some(t.comments.clone()),
                     Default::default()

--- a/crates/react_refresh/Cargo.toml
+++ b/crates/react_refresh/Cargo.toml
@@ -8,20 +8,19 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 common = { path = "../common" }
-swc_core = { version = "0.40.36", features = [
+swc_core = { version = "0.59", features = [
   "ecma_ast",
   "ecma_quote",
   "ecma_utils",
   "ecma_visit",
-  "plugin_transform",
+  "ecma_plugin_transform",
 ] }
 
 [dev-dependencies]
-swc_core = { version = "0.40.36", features = [
+swc_core = { version = "0.59", features = [
+  "ecma_parser",
+  "ecma_transforms_compat",
   "ecma_transforms_react",
-  "testing_transform", 
+  "testing_transform",
 ] }
-swc_ecma_parser = "0.122.23"
-swc_ecma_transforms_base = "0.111.38"
-swc_ecma_transforms_compat = "0.136.25"
 testing = "0.31.13"

--- a/crates/react_refresh/src/lib.rs
+++ b/crates/react_refresh/src/lib.rs
@@ -309,9 +309,9 @@ mod tests {
         ecma::{
             transforms::{base::resolver, testing::test},
             visit::{as_folder, Fold},
+            parser::Syntax,
         },
     };
-    use swc_ecma_parser::Syntax;
 
     fn transform(config: Option<Config>, path: Option<&Path>) -> impl Fold {
         chain!(

--- a/crates/react_refresh/tests/fixture.rs
+++ b/crates/react_refresh/tests/fixture.rs
@@ -3,13 +3,16 @@ use std::{fs::read_to_string, path::PathBuf};
 use common::parse_plugin_config;
 use swc_core::{
     common::{chain, Mark},
-    ecma::transforms::{
-        base::resolver,
-        react::{react, Options, RefreshOptions},
-        testing::test_fixture,
+    ecma::{
+        parser::{EsConfig, Syntax},
+        transforms::{
+            base::resolver,
+            compat::es2015,
+            react::{react, Options, RefreshOptions},
+            testing::test_fixture,
+        },
     },
 };
-use swc_ecma_parser::{EsConfig, Syntax};
 use swc_jotai_react_refresh::react_refresh;
 use testing::fixture;
 
@@ -46,7 +49,7 @@ fn test(input: PathBuf) {
                     },
                     top_level_mark
                 ),
-                swc_ecma_transforms_compat::es2015(
+                es2015(
                     unresolved_mark,
                     Some(t.comments.clone()),
                     Default::default()


### PR DESCRIPTION
Bumps swc_core to the recommended 0.59 https://swc.rs/docs/plugin/selecting-swc-core

Also removes unneeded deps and uses `swc_core` features instead to
ensure the deps are correctly versioned
