### PR TITLE
react_refresh: Rewrite main loop

### DIFF
--- a/crates/react_refresh/src/lib.rs
+++ b/crates/react_refresh/src/lib.rs
@@ -151,7 +151,7 @@ impl VisitMut for ReactRefreshTransformVisitor {
         {
             sym.to_string()
         } else {
-            "wat".to_string()
+            "[missing-declarator]".to_string()
         };
 
         self.access_path.push(key);


### PR DESCRIPTION
This turned into an all-in-one commit:

 * Move the logic to the `visit_mut_*` functions from VisitMut.
 * Make atom key names more flexible to support e.g. #26

The largest change is the fact that we perform most of the work directly
in the visitor functions.  For applicable calls to `atom` (and friends)
we replace the `CallExpr` right then and there.  This makes it so that
we don't need to deal with `export` handling, or accidentally replace
entire expressions with erroneous cached atoms (See e.g. the failing
test in #36).  This also solves other open issues, like #26 , #34 , and #35 .

Fixes #26 
Fixes #34 
Fixes #35 

---

I built this on top of #37, but I suppose technically speaking that's not necessary. This is a pretty large change, so if you think this is a direction to pursue it might make sense to rethink that change in the context of this anyways.

There's still some cleanup I can do, and probably a bunch of edge cases I've missed. I intend to look at these next.
